### PR TITLE
fix: System Management modify ui

### DIFF
--- a/src/routes/System/Resource/index.js
+++ b/src/routes/System/Resource/index.js
@@ -489,8 +489,8 @@ export default class Resource extends Component {
       <div className="plug-content-wrap">
         <Row gutter={20}>
           <Col span={6} style={{ minWidth: 280 }}>
+            <h3>{getIntlContent("SHENYU.SYSTEM.RESOURCE.MENULIST.TITLE")}</h3>
             <div className="table-header">
-              <h3>{getIntlContent("SHENYU.SYSTEM.RESOURCE.MENULIST.TITLE")}</h3>
               <div className={styles.headerSearch}>
                 <AuthButton perms="system:resource:list">
                   <Search
@@ -523,11 +523,9 @@ export default class Resource extends Component {
             ) : null}
           </Col>
           <Col span={18}>
+            <h3>{getIntlContent("SHENYU.SYSTEM.RESOURCE.BUTTONLIST.TITLE")}</h3>
             <div className="table-header">
               <div style={{ display: "flex", alignItems: "center" }}>
-                <h3>
-                  {getIntlContent("SHENYU.SYSTEM.RESOURCE.BUTTONLIST.TITLE")}
-                </h3>
                 <AuthButton perms="system:resource:deleteButton">
                   <Popconfirm
                     title={getIntlContent("SHENYU.COMMON.DELETE")}
@@ -538,7 +536,7 @@ export default class Resource extends Component {
                     okText={getIntlContent("SHENYU.COMMON.SURE")}
                     cancelText={getIntlContent("SHENYU.COMMON.CALCEL")}
                   >
-                    <Button style={{ marginLeft: 20 }} type="danger">
+                    <Button type="danger">
                       {getIntlContent("SHENYU.SYSTEM.DELETEDATA")}
                     </Button>
                   </Popconfirm>


### PR DESCRIPTION
On mac M1 models or on smaller screens of other computers (such as 1400*787 resolution), some buttons cannot be fully displayed, affecting users' usage. And it affects the page's aesthetics.

To Reproduce
Steps to reproduce the behavior:

1. Open the shenyu-dashboard on a screen with 1400*787resolution.
2. Navigate to the System Manage-Resource.
3. Observe the layout of buttons — some are partially or fully cut off from view.

Screenshots
<img width="1910" height="915" alt="0DDF9EFB-73A5-41E2-9208-D9FE5C6A0342" src="https://github.com/user-attachments/assets/8f4033bd-8677-45f0-817b-84b93d1b75bb" />

The effect after the repair
<img width="1436" height="683" alt="83D572A6-3D40-434B-95AB-F86D492C07A0" src="https://github.com/user-attachments/assets/049a88fd-b09c-4f3d-bba4-2988ab826783" />
