### PR TITLE
fix: Compatible UI layout

### DIFF
--- a/src/routes/System/Resource/index.js
+++ b/src/routes/System/Resource/index.js
@@ -488,7 +488,7 @@ export default class Resource extends Component {
     return (
       <div className="plug-content-wrap">
         <Row gutter={20}>
-          <Col span={6} style={{ minWidth: 280 }}>
+          <Col span={7}>
             <h3>{getIntlContent("SHENYU.SYSTEM.RESOURCE.MENULIST.TITLE")}</h3>
             <div className="table-header">
               <div className={styles.headerSearch}>
@@ -522,7 +522,7 @@ export default class Resource extends Component {
               </Tree>
             ) : null}
           </Col>
-          <Col span={18}>
+          <Col span={17}>
             <h3>{getIntlContent("SHENYU.SYSTEM.RESOURCE.BUTTONLIST.TITLE")}</h3>
             <div className="table-header">
               <div style={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
On smaller screens (e.g., 1366x769 resolution), The layout style is in a mess. The layout on the right side is located below the left part, which affects the page's aesthetics. If the user does not scroll down, it will confuse the user and some functions on the right side will be missing.

To Reproduce
Steps to reproduce the behavior:

1. Open the shenyu-dashboard on a screen with 1366x769 resolution.
2. Navigate to System Manage-Resource.
3. The layout on the left and right sides is disordered, turning into an up-and-down layout

Screenshots：
<img width="1337" height="822" alt="image" src="https://github.com/user-attachments/assets/e902a0ac-7b2b-4814-a1c0-5467051e2fd9" />

I modified the layout on the left and right sides and solved the above problem
The adjusted visual presentation：
<img width="2716" height="1374" alt="image" src="https://github.com/user-attachments/assets/a8a590c2-56d4-4ea4-84ae-da6d161106cc" />
