### PR TITLE
fix:mcpServer page blank

### DIFF
--- a/src/routes/Plugin/McpServer/index.js
+++ b/src/routes/Plugin/McpServer/index.js
@@ -1154,7 +1154,7 @@ export default class McpServer extends Component {
         key: "requestParams",
         render: (text) => {
           const handle = JSON.parse(text);
-          const parameters = handle.parameters;
+          const parameters = handle?.parameters || {};
           return (
             <Popover
               content={


### PR DESCRIPTION
fix:mcpServer page blank.  #544 
When navigating from a custom proxy plugin page to the mcpServer page, a blank screen issue still occurs.
<img width="2946" height="1430" alt="image" src="https://github.com/user-attachments/assets/fbf27d3c-20f9-4180-b8f0-3ff06605e021" />

Then, navigate to the mcpServer page. The page shows a blank screen. 
<img width="2056" height="954" alt="image" src="https://github.com/user-attachments/assets/34963b91-df97-4321-9c1b-dba840f74973" />
<img width="2524" height="926" alt="image" src="https://github.com/user-attachments/assets/60e271bf-b39f-4c38-bd81-aa720a3eef5f" />
